### PR TITLE
表記ゆれ対策のためにprh導入

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -28,6 +28,11 @@
     "ja-technical-writing/max-kanji-continuous-len": false, // 漢字6文字制限の無効化
     "@proofdict/proofdict": { // 表記揺れを検知する
       "dictURL": "https://azu.github.io/proof-dictionary/"
+    },
+    "prh": {
+      "rulePaths": [
+        "./prh.yml"
+      ]
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,13 @@
       "devDependencies": {
         "@proofdict/textlint-rule-proofdict": "3.1.2",
         "@slidev/cli": "0.42.7",
+        "prh": "5.4.4",
         "renovate": "36.42.4",
         "textlint": "13.3.3",
         "textlint-filter-rule-comments": "1.2.2",
         "textlint-rule-preset-ja-spacing": "2.3.0",
         "textlint-rule-preset-ja-technical-writing": "8.0.0",
+        "textlint-rule-prh": "5.3.0",
         "textlint-rule-spellcheck-tech-word": "5.0.0",
         "zenn-cli": "0.1.144"
       },

--- a/package.json
+++ b/package.json
@@ -14,11 +14,13 @@
   "devDependencies": {
     "@proofdict/textlint-rule-proofdict": "3.1.2",
     "@slidev/cli": "0.42.7",
+    "prh": "5.4.4",
     "renovate": "36.42.4",
     "textlint": "13.3.3",
     "textlint-filter-rule-comments": "1.2.2",
     "textlint-rule-preset-ja-spacing": "2.3.0",
     "textlint-rule-preset-ja-technical-writing": "8.0.0",
+    "textlint-rule-prh": "5.3.0",
     "textlint-rule-spellcheck-tech-word": "5.0.0",
     "zenn-cli": "0.1.144"
   }

--- a/prh.yml
+++ b/prh.yml
@@ -1,0 +1,22 @@
+# see prh.yml rules
+# https://github.com/vvakame/prh/blob/master/misc/prh.yml
+# see more samples
+# https://github.com/prh/rules/blob/master/media/techbooster.yml
+rules:
+  - expected: GitHub Actions
+  - expected: Four Keys
+  # "+"を含めて正しく認識されるためにクォーテーションが必要
+  - expected: "Findy Team+"
+    patterns:
+      - /Findy Teams?\+/i
+    specs:
+      - from: Findy Teams+
+        to: Findy Team+
+  - expected: Node.js
+    patterns:
+      - /node.?js/i
+    specs:
+      - from: nodejs
+        to: Node.js
+      - from: node.js
+        to: Node.js


### PR DESCRIPTION
既に導入されている https://github.com/proofdict/proofdict と https://github.com/prh/prh のどちらを採用するか悩みましたが、個人的にはprhのyamlの方が記述量が少ないのでとりあえずはこちらで十分かなと思いました。
ライブラリがメンテされているかの観点も迷ったのですが、どちらも最近それほど更新されていない（良い意味で枯れてる？）のと、prhは自分がプライベートでずっと使っていて今日まで特に問題になったことがないので大丈夫だと思います。

proofdictの記述例
https://github.com/proofdict/proofdict

prhの記述例
https://github.com/prh/prh/blob/master/misc/prh.yml