### PR TITLE
feat: add writer template

### DIFF
--- a/articles/template/productivity-weekly-template.md.tmpl
+++ b/articles/template/productivity-weekly-template.md.tmpl
@@ -32,6 +32,12 @@ user_defined: {"publish_link": "https://zenn.dev/korosuke613/articles/productivi
 
 対象のトピックでは、文章の最後に `本項の執筆者: <執筆者名>` を追加しています。
 
+<!-- _本項の執筆者: [@korosuke613](https://zenn.dev/korosuke613)_ -->
+<!-- _本項の執筆者: [@defaultcf](https://zenn.dev/defaultcf)_ -->
+<!-- _本項の執筆者: [@Kesin11](https://zenn.dev/kesin11)_ -->
+<!-- _本項の執筆者: [@r4mimu](https://zenn.dev/r4mimu)_ -->
+<!-- _本項の執筆者: [@uta8a](https://zenn.dev/uta8a)_ -->
+
 今週の共同著者は次の方です。
 - [@korosuke613](https://zenn.dev/korosuke613)
 <!-- - [@defaultcf](https://zenn.dev/defaultcf) -->


### PR DESCRIPTION
- Productivity Weekly のテンプレートに「本校の執筆者」を組み込みました
  - 毎回どう書くんだっけ、となって以前の記事を確認していました
  - 記事内で参照できるようにすることで、その手間を軽減したいという背景(自分だけ？)