### PR TITLE
chore: move comment location

### DIFF
--- a/articles/template/productivity-weekly-template.md.tmpl
+++ b/articles/template/productivity-weekly-template.md.tmpl
@@ -9,7 +9,14 @@ type: "idea"
 topics: ["ProductivityWeekly", "生産性向上"]
 published: false
 publication_name: "cybozu_ept"
-user_defined: {"publish_link": "https://zenn.dev/cybozu_ept/articles/productivity-weekly-{{ .Env.PW_YEAR }}{{ .Env.PW_MONTH }}{{ .Env.PW_DAY }}"}
+user_defined: 
+  publish_link: "https://zenn.dev/cybozu_ept/articles/productivity-weekly-{{ .Env.PW_YEAR }}{{ .Env.PW_MONTH }}{{ .Env.PW_DAY }}"
+  note: |
+    _本項の執筆者: [@korosuke613](https://zenn.dev/korosuke613)_
+    _本項の執筆者: [@defaultcf](https://zenn.dev/defaultcf)_
+    _本項の執筆者: [@Kesin11](https://zenn.dev/kesin11)_
+    _本項の執筆者: [@r4mimu](https://zenn.dev/r4mimu)_
+    _本項の執筆者: [@uta8a](https://zenn.dev/uta8a)_
 ---
 
 こんにちは。サイボウズ株式会社 [生産性向上チーム](https://note.com/cybozu_dev/n/n1c1b44bf72f6)の平木場です。
@@ -31,12 +38,6 @@ user_defined: {"publish_link": "https://zenn.dev/cybozu_ept/articles/productivit
 2023-05-10 号から、実験的に生産性向上チームの他メンバーにいくつかのトピックを紹介していただくことにしています。
 
 対象のトピックでは、文章の最後に `本項の執筆者: <執筆者名>` を追加しています。
-
-<!-- _本項の執筆者: [@korosuke613](https://zenn.dev/korosuke613)_ -->
-<!-- _本項の執筆者: [@defaultcf](https://zenn.dev/defaultcf)_ -->
-<!-- _本項の執筆者: [@Kesin11](https://zenn.dev/kesin11)_ -->
-<!-- _本項の執筆者: [@r4mimu](https://zenn.dev/r4mimu)_ -->
-<!-- _本項の執筆者: [@uta8a](https://zenn.dev/uta8a)_ -->
 
 今週の共同著者は次の方です。
 - [@korosuke613](https://zenn.dev/korosuke613)


### PR DESCRIPTION
because: if add markdown comment, so render unnecessary blank lines in zenn-editor

![image](https://github.com/korosuke613/zenn-articles/assets/20027695/2ba92a77-3e16-4dac-a446-84bd3f6c0745)

ref: #560 