### PR TITLE
Send commit status from AI-review workflow

### DIFF
--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      statuses: write
     uses: ./.github/workflows/reusable-ai-review.yaml
     secrets: inherit
     with:

--- a/.github/workflows/reusable-ai-review.yaml
+++ b/.github/workflows/reusable-ai-review.yaml
@@ -23,6 +23,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      statuses: write
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
     steps:
@@ -57,6 +58,19 @@ jobs:
           \cp -f ${{ runner.temp }}/ai-review/deno.lock .
           \cp -rf ${{ runner.temp }}/ai-review/tools .
           ls deno.lock tools
+
+      - name: Set pending status
+        uses: actions/github-script@v6
+        with:
+          script: |
+            await github.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ steps.setup_branches.outputs.latest_git_sha }}',
+              state: 'pending',
+              description: 'AI Review is in progress',
+              context: 'AI Review'
+            })
 
       - uses: ./.github/actions/setup-deno
 
@@ -112,3 +126,19 @@ jobs:
             echo '```'
           } >> "$COMMENT_FILE"
           gh pr comment ${{ inputs.pr_number }} --body-file "$COMMENT_FILE"
+
+      - name: Set final status
+        if: always()
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const state = github.context.job.conclusion === 'success' ? 'success' : 'failure';
+            const description = state === 'success' ? 'AI Review completed successfully' : 'AI Review failed';
+            await github.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ steps.setup_branches.outputs.latest_git_sha }}',
+              state: state,
+              description: description,
+              context: 'AI Review'
+            })

--- a/.github/workflows/reusable-ai-review.yaml
+++ b/.github/workflows/reusable-ai-review.yaml
@@ -60,7 +60,7 @@ jobs:
           ls deno.lock tools
 
       - name: Set pending status
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             await github.repos.createCommitStatus({
@@ -129,7 +129,7 @@ jobs:
 
       - name: Set final status
         if: always()
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const state = github.context.job.conclusion === 'success' ? 'success' : 'failure';

--- a/.github/workflows/reusable-ai-review.yaml
+++ b/.github/workflows/reusable-ai-review.yaml
@@ -17,6 +17,7 @@ env:
   # deno が package.json にあるパッケージを deno.lock で管理しようとするのを防ぐ
   # ref: https://github.com/denoland/deno/issues/17916
   DENO_NO_PACKAGE_JSON: 1
+  RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
   review:
@@ -68,6 +69,7 @@ jobs:
               repo: context.repo.repo,
               sha: '${{ steps.setup_branches.outputs.latest_git_sha }}',
               state: 'pending',
+              target_url: process.env.RUN_URL,
               description: 'AI Review is in progress',
               context: 'AI Review'
             })
@@ -132,13 +134,16 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const state = context.job.conclusion === 'success' ? 'success' : 'failure';
+            const state = process.env.JOB_STATUS === 'success' ? 'success' : 'failure';
             const description = state === 'success' ? 'AI Review completed successfully' : 'AI Review failed';
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
               sha: '${{ steps.setup_branches.outputs.latest_git_sha }}',
               state: state,
+              target_url: process.env.RUN_URL,
               description: description,
               context: 'AI Review'
             })
+        env:
+          JOB_STATUS: ${{ job.status }}

--- a/.github/workflows/reusable-ai-review.yaml
+++ b/.github/workflows/reusable-ai-review.yaml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            await github.repos.createCommitStatus({
+            await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
               sha: '${{ steps.setup_branches.outputs.latest_git_sha }}',
@@ -134,7 +134,7 @@ jobs:
           script: |
             const state = github.context.job.conclusion === 'success' ? 'success' : 'failure';
             const description = state === 'success' ? 'AI Review completed successfully' : 'AI Review failed';
-            await github.repos.createCommitStatus({
+            await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
               sha: '${{ steps.setup_branches.outputs.latest_git_sha }}',

--- a/.github/workflows/reusable-ai-review.yaml
+++ b/.github/workflows/reusable-ai-review.yaml
@@ -132,7 +132,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const state = github.context.job.conclusion === 'success' ? 'success' : 'failure';
+            const state = context.job.conclusion === 'success' ? 'success' : 'failure';
             const description = state === 'success' ? 'AI Review completed successfully' : 'AI Review failed';
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,

--- a/.github/workflows/test-ai-review.yaml
+++ b/.github/workflows/test-ai-review.yaml
@@ -17,6 +17,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      statuses: write
     uses: ./.github/workflows/reusable-ai-review.yaml
     secrets: inherit
     with:


### PR DESCRIPTION
/ai-reviewでレビューbotを呼び出したとき、レビューのワークフローが正しく開始したのかどうか、進捗がどうか、最終的なsuccess/failedのステータスが分かりにくい問題をAI-reviewのワークフローからcommit statusを作成することで解消しました。

動作確認は自分のリポジトリの方で行いました。
https://github.com/Kesin11/korosuke613-zenn-articles/actions/runs/11101766261
デバッグはOpenAIへのAPI部分を消して、test-ai-reviewのworkflow_dispatchから起動してコミットステータスが付与されることまで確認しています。