### PR TITLE
chore: Allow leader's custom

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -16,13 +16,13 @@
       "no-exclamation-question-mark": false, // !?文字制限を無効化
       "ja-no-mixed-period": {
         // 読点（。）で文が終わるようにする
-        "allowPeriodMarks": [":", ".", "・", "：", "．"],
+        "allowPeriodMarks": [":", ".", "・", "：", "．", "…"],
         "allowEmojiAtEnd": true // 末尾の絵文字を許可
       },
       "max-comma": false, // コンマの連続を許可
       "ja-no-successive-word": {
         "allowOnomatopee": true,
-        "allow": ["○", "・", "。", "など", "まあ", "て", "!", "！", "つよ"]
+        "allow": ["○", "・", "。", "など", "まあ", "て", "!", "！", "つよ", "…"]
       },
       "max-ten": {
         "max": 10


### PR DESCRIPTION
## 背景

textlint が三点リーダー（…）に関する以下の慣習に従ってほしいです:

- 連続する三点リーダーの数は偶数倍
- 三点リーダーで文が終わる場合は句点をつけない

c.f. https://ja.wikipedia.org/wiki/%E3%83%AA%E3%83%BC%E3%83%80%E3%83%BC_(%E8%A8%98%E5%8F%B7)

## やったこと

以下の2つです:

- 三点リーダーが連続することを許可
- 三点リーダーを句点扱いする