### PR TITLE
fix: update gpt-4o

### DIFF
--- a/tools/deps.ts
+++ b/tools/deps.ts
@@ -3,11 +3,7 @@ export { matter };
 export { marked } from "npm:marked@6.0.0";
 export type { Token, Tokens } from "npm:marked@6.0.0";
 
-export { OpenAI } from "https://deno.land/x/openai@v4.56.0/mod.ts";
-export type {
-  ChatCompletionCreateParamsNonStreaming,
-  CompletionUsage,
-} from "https://deno.land/x/openai@v4.56.0/resources/mod.ts";
+export { OpenAI } from "jsr:@openai/openai";
 
 export { join } from "https://deno.land/std@0.224.0/path/join.ts";
 export { LogRecord } from "https://deno.land/std@0.224.0/log/mod.ts";

--- a/tools/libs/AiReviewer.ts
+++ b/tools/libs/AiReviewer.ts
@@ -32,8 +32,8 @@ export type OpenAIPricingData = {
 export class AiReviewer {
   private readonly openai: OpenAI;
   private static readonly SYSTEM_PROMPT = `
-あなたは日本語文章を校正するアシスタントです。
-与えられたマークダウン形式の文章で、誤字・脱字、および、文法誤りのある行を抜き出し、修正した行を出力してください。
+あなたは日本語技術記事を校正するアシスタントです。
+与えられたマークダウン形式の文章で、誤字・脱字、文法誤り、論理的に誤っている行を抜き出し、修正した行を出力してください。
 その際、確実に修正すべき誤りのみを出力してください。
 また、以下のルールに従って修正を行ってください。
 - 句読点の追加や削除はしない
@@ -53,19 +53,13 @@ export class AiReviewer {
   private static readonly pricing: Record<string, OpenAIPricingData> = {
     // ref: https://openai.com/api/pricing/
     "gpt-4o": {
-      input: 5 / (1 * 1000000),
-      output: 15 / (1 * 1000000),
-    },
-    "gpt-4o-2024-08-06": {
-      input: 5 / (1 * 1000000),
-      output: 15 / (1 * 1000000),
+      input: 2.5 / (1 * 1000000),
+      output: 10 / (1 * 1000000),
     },
   };
   static readonly defaultOptions: AiReviewerOptions = {
     max_tokens: 1024,
-    // GPT-4o が Structured Outputs にまだ対応してないため、最新版である gpt-4o-2024-08-06 を使用
-    // TODO: GPT-4o が Structured Outputs に対応したら、GPT-4o を使用する
-    model: "gpt-4o-2024-08-06",
+    model: "gpt-4o",
     logging: true,
     reviewNum: 5,
   };

--- a/tools/libs/AiReviewer.ts
+++ b/tools/libs/AiReviewer.ts
@@ -1,11 +1,5 @@
 import { DiagnosticResult } from "./ReviewDogJsonLine.ts";
-import {
-  ChatCompletionCreateParamsNonStreaming,
-  CompletionUsage,
-  log,
-  LogRecord,
-  OpenAI,
-} from "../deps.ts";
+import { log, LogRecord, OpenAI } from "../deps.ts";
 
 export type ReviewResult = {
   review: {
@@ -33,7 +27,7 @@ export class AiReviewer {
   private readonly openai: OpenAI;
   private static readonly SYSTEM_PROMPT = `
 あなたは日本語技術記事を校正するアシスタントです。
-与えられたマークダウン形式の文章で、誤字・脱字、文法誤り、論理的に誤っている行を抜き出し、修正した行を出力してください。
+与えられたマークダウン形式の文章で、誤字・脱字、文法誤り、論理的・技術的な誤りのある行を抜き出し、修正した行を出力してください。
 その際、確実に修正すべき誤りのみを出力してください。
 また、以下のルールに従って修正を行ってください。
 - 句読点の追加や削除はしない
@@ -56,9 +50,24 @@ export class AiReviewer {
       input: 2.5 / (1 * 1000000),
       output: 10 / (1 * 1000000),
     },
+    "o1-mini": {
+      input: 3 / (1 * 1000000),
+      output: 12 / (1 * 1000000),
+    },
+    "o1-preview": {
+      input: 15 / (1 * 1000000),
+      output: 60 / (1 * 1000000),
+    },
+    "o1": {
+      input: 15 / (1 * 1000000),
+      output: 60 / (1 * 1000000),
+    },
   };
   static readonly defaultOptions: AiReviewerOptions = {
     max_tokens: 1024,
+    // o1-mini か o1-preview が使いたいが、system role が使えない、structured outputs が使えないなどまだ制限があるため、gpt-4o を使用
+    // ref: https://community.openai.com/t/o1-models-do-not-support-system-role-in-chat-completion/953880/12
+    // ref: https://platform.openai.com/docs/guides/structured-outputs#supported-models
     model: "gpt-4o",
     logging: true,
     reviewNum: 5,
@@ -152,7 +161,7 @@ export class AiReviewer {
   };
 
   createReviewInput = (markdown: string) => {
-    const input: ChatCompletionCreateParamsNonStreaming = {
+    const input: OpenAI.ChatCompletionCreateParamsNonStreaming = {
       model: this.options.model,
       messages: [
         {
@@ -168,7 +177,7 @@ export class AiReviewer {
         },
       ],
       temperature: 1,
-      max_tokens: this.options.max_tokens,
+      max_completion_tokens: this.options.max_tokens,
       top_p: 1,
       frequency_penalty: 0,
       presence_penalty: 0,
@@ -209,7 +218,7 @@ export class AiReviewer {
     return response.replaceAll("```json", "").replaceAll("```", "");
   };
 
-  getPricing = (usage?: CompletionUsage) => {
+  getPricing = (usage?: OpenAI.CompletionUsage) => {
     if (usage === undefined) {
       if (this.options.logging) log.warn("No usage data from OpenAI.");
       return undefined;
@@ -221,6 +230,7 @@ export class AiReviewer {
       AiReviewer.pricing[this.options.model].output;
 
     return {
+      model: this.options.model,
       tokens: usage,
       pricing: {
         input: `${input.toFixed(3)} USD`,


### PR DESCRIPTION
このプルリクエストには、システムプロンプトを更新し、OpenAIモデルの価格データを調整するための `tools/libs/AiReviewer.ts` ファイルへの変更が含まれています。最も重要な変更は、システムプロンプトの変更と `gpt-4o` モデルの価格データの更新です。

システムプロンプトの更新：

* アシスタントが日本語の技術記事の校正用であることを指定し、修正に論理エラーを含めるようにシステムプロンプトを変更しました。

価格データの調整：

* `gpt-4o` モデルの入出力価格を更新しました。
* デフォルトのモデルを `gpt-4o-2024-08-06` から `gpt-4o` に変更しました。